### PR TITLE
criacao da chave estrangeira de cargo do usuario

### DIFF
--- a/Backend/src/main/resources/config/liquibase/changelogs/202109161245_FK_cargo_usuario.xml
+++ b/Backend/src/main/resources/config/liquibase/changelogs/202109161245_FK_cargo_usuario.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+    <changeSet id="202109161245" author="TheoGallo">
+        <addForeignKeyConstraint baseTableName="USUARIO" baseColumnNames="CARGO" constraintName="FK_CARGO"
+                                 referencedTableName="CARGO"
+                                 referencedColumnNames="ID" />
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
Chave estrangeira da tabela usuario, faz referencia a tabela cargos, de domínio fixo. 